### PR TITLE
Feat/force listening channel update

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -74,7 +74,8 @@ import {
     MessageUser,
     BroadcasterData, Broadcaster,
     MessageData, Mess,
-    OptionsProvider, ChannelOptions
+    OptionsProvider, ChannelOptions,
+    API, RefreshChatListeners
 } from './src/decorators/ChatData.decorators';
 
 // ==============================
@@ -108,6 +109,7 @@ import InMemoryTokenRepository from './src/example/repositories/InMemoryToken.re
 // =================================
 
 import { IListenChannelsProvider } from './src/types/ListenChannels.provider.types';
+import { GetListenerChannelsRefreshFunction } from './src/providers/ListenChannels.provider';
 
 // ==================================
 //   Channel Options Provider Types
@@ -204,6 +206,7 @@ export {
     BroadcasterData, Broadcaster,
     MessageData, Mess,
     OptionsProvider, ChannelOptions,
+    API, RefreshChatListeners,
 
     // Chat Data Injector Objects
     PartialTwitchUser, TwitchUser, ChatterUser,
@@ -221,6 +224,7 @@ export {
 
     // Listen Channel Provider Types
     IListenChannelsProvider,
+    GetListenerChannelsRefreshFunction,
 
     // Channel Options Provider Types
     IChannelOptionsProvider, TChannelOptions, ChannelOptionsProvider,

--- a/src/decorators/ChatData.decorators.ts
+++ b/src/decorators/ChatData.decorators.ts
@@ -29,6 +29,7 @@ const MessageUser = CreateChatDataDecorator(ChatDataType.MESSAGE_USER);
 const OptionsProvider = CreateChatDataDecorator(ChatDataType.OPTIONS_PROVIDER);
 const ChannelOptions = CreateChatDataDecorator(ChatDataType.CHANNEL_OPTIONS);
 const API = CreateChatDataDecorator(ChatDataType.API_CLIENT);
+const RefreshChatListeners = CreateChatDataDecorator(ChatDataType.REFRESH_CHAT_LISTENERS);
 
 export { 
     Raw, 
@@ -37,5 +38,6 @@ export {
     BroadcasterData, Broadcaster,
     MessageData, Mess,
     OptionsProvider, ChannelOptions,
-    API
+    API,
+    RefreshChatListeners
 };

--- a/src/example/commands/Example.command.ts
+++ b/src/example/commands/Example.command.ts
@@ -1,5 +1,5 @@
 import { ChatCommand } from "../../decorators/ChatCommand.decorator";
-import { API, BroadcasterData, ChannelOptions, Mess, MessageUser, OptionsProvider, Raw } from "../../decorators/ChatData.decorators";
+import { API, BroadcasterData, ChannelOptions, Mess, MessageUser, OptionsProvider, Raw, RefreshChatListeners } from "../../decorators/ChatData.decorators";
 import { ChatterUser, PartialTwitchUser } from "../../objects/TwitchUser.object";
 import { ChannelOptionsProvider } from "../../providers/ChannelOptions.provider";
 import { ChatCommandExecution, ChatCommandExecutionGuard, ChatCommandExecutionGuardAvaliableResults, ChatCommandPostExecution, ChatCommandPreExecution } from "../../types/ChatCommand.types";
@@ -31,7 +31,8 @@ export default class ExampleCommand implements ChatCommandExecutionGuard, ChatCo
         @OptionsProvider() provider: ChannelOptionsProvider<ChannelOptionsExtend>,
         @ChannelOptions() options: ChannelOptionsExtend,
         @BroadcasterData() broadcasterData: PartialTwitchUser,
-        @Mess() message: TwitchChatMessage
+        @Mess() message: TwitchChatMessage,
+        @RefreshChatListeners() refreshChannels: () => void
     ): Promise<void> {
         console.log('Execution logic');
         await message.reply(`Example command executed ${options.eXampleExecutionCounter} times.`);
@@ -40,6 +41,7 @@ export default class ExampleCommand implements ChatCommandExecutionGuard, ChatCo
             ...options,
             eXampleExecutionCounter: options.eXampleExecutionCounter + 1
         })
+        refreshChannels();
     }
 
     async postExecution(

--- a/src/providers/ListenChannels.provider.ts
+++ b/src/providers/ListenChannels.provider.ts
@@ -54,12 +54,13 @@ export default class ListenChannelsProvider {
         return channels;
     }
 
+    // TODO: Wystaw do użycia - rozwiązuje to jeden feature z issue #2 https://github.com/tfxjs/tfxjs/issues/2
     /**
      * Refresh channels and emit event if there are any changes
      * @returns True if channels were updated, false otherwise
      */
     async refreshChannels(): Promise<boolean> {
-        this.logger.debug('Refreshing channels');
+        this.logger.info('Refreshing channels');
         const channelIds = await this.getChannelIds();
         const lastChannelIds = this._lastChannelIds;
 
@@ -148,4 +149,9 @@ export default class ListenChannelsProvider {
         this.callbacks = this.callbacks.filter((cb) => cb !== callback);
         this.logger.debug(`Removed callback`);
     }
+}
+
+export function GetListenerChannelsRefreshFunction(): typeof ListenChannelsProvider.prototype.refreshChannels {
+    const provider = Container.get(DINames.ListenChannelsProvider) as ListenChannelsProvider;
+    return provider.refreshChannels.bind(provider);
 }

--- a/src/services/ChatDataInjector.service.ts
+++ b/src/services/ChatDataInjector.service.ts
@@ -6,6 +6,7 @@ import ChannelChatMessageEventData from "../types/EventSub_Events/ChannelChatMes
 import {ChatterUser, PartialTwitchUser, TwitchUser} from "../objects/TwitchUser.object";
 import {ChatMessage, TwitchChatMessage} from "../objects/ChatMessage.object";
 import { ChannelOptionsProvider } from "../providers/ChannelOptions.provider";
+import ListenChannelsProvider, { GetListenerChannelsRefreshFunction } from "../providers/ListenChannels.provider";
 
 @Service(DINames.ChatDataInjectorService)
 export default class ChatDataInjectorService {
@@ -43,6 +44,7 @@ export default class ChatDataInjectorService {
                 return await provider.getChannelOptions(data.broadcaster_user_id);
             },
             [ChatDataType.API_CLIENT]: (data: ChannelChatMessageEventData) => Container.get(DINames.APIClient),
+            [ChatDataType.REFRESH_CHAT_LISTENERS]: (data: ChannelChatMessageEventData) => GetListenerChannelsRefreshFunction()
         };
 
         const mappedData = await dataMaps[type](data);

--- a/src/types/ChatDataInjector.types.ts
+++ b/src/types/ChatDataInjector.types.ts
@@ -2,6 +2,7 @@ import APIClient from "../clients/Api.client";
 import {ChatMessage, TwitchChatMessage} from "../objects/ChatMessage.object";
 import {ChatterUser, PartialTwitchUser, TwitchUser} from "../objects/TwitchUser.object";
 import { ChannelOptionsProvider } from "../providers/ChannelOptions.provider";
+import ListenChannelsProvider from "../providers/ListenChannels.provider";
 import ChannelChatMessageEventData from "./EventSub_Events/ChannelChatMessageEventData.types";
 import { Badge } from "./twitch/TwitchUser.types";
 
@@ -22,6 +23,8 @@ export enum ChatDataType {
     CHANNEL_OPTIONS = 'CHANNEL_OPTIONS', // Channel options
 
     API_CLIENT = 'API_CLIENT', // Twitch API client
+
+    REFRESH_CHAT_LISTENERS = 'REFRESH_CHAT_LISTENERS', // Refresh chat listeners - ListenChannelsProvider method
 }
 
 export type ChatDataTypeMap = {
@@ -41,4 +44,6 @@ export type ChatDataTypeMap = {
     [ChatDataType.CHANNEL_OPTIONS]: Record<string, any>; // ChannelBaseOptions & ExtendedByUser
 
     [ChatDataType.API_CLIENT]: APIClient;
+
+    [ChatDataType.REFRESH_CHAT_LISTENERS]: () => typeof ListenChannelsProvider.prototype.refreshChannels;
 };


### PR DESCRIPTION
- Added `GetListenerChannelsRefreshFunction`, which returns the `refreshChannels` method from `ListenChannelsProvider`. Calling this function triggers an instant refresh of the listening channels using `getChannelIds()` from `IListenChannelsProvider`.  
- Added the `@RefreshChatListeners` decorator, which returns or executes `GetListenerChannelsRefreshFunction`, allowing command or listener execution.  
- Exported `GetListenerChannelsRefreshFunction` and the `RefreshChatListeners` decorator.  
- Exported the missing API decorator.

Resolves #2 