### PR TITLE
Fix: Better channel options management

### DIFF
--- a/src/decorators/ChatData.decorators.ts
+++ b/src/decorators/ChatData.decorators.ts
@@ -26,8 +26,18 @@ const Broadcaster = CreateChatDataDecorator(ChatDataType.BROADCASTER);
 const MessageData = CreateChatDataDecorator(ChatDataType.MESSAGE_DATA);
 const Mess = CreateChatDataDecorator(ChatDataType.MESSAGE);
 const MessageUser = CreateChatDataDecorator(ChatDataType.MESSAGE_USER);
+
+/**
+ * @deprecated Use a `OptionsManager` decorator instead.
+ */
 const OptionsProvider = CreateChatDataDecorator(ChatDataType.OPTIONS_PROVIDER);
+/**
+ * @deprecated Use a `OptionsManager` decorator instead.
+ */
 const ChannelOptions = CreateChatDataDecorator(ChatDataType.CHANNEL_OPTIONS);
+
+const OptionsManager = CreateChatDataDecorator(ChatDataType.OPTIONS_MANAGER);
+
 const API = CreateChatDataDecorator(ChatDataType.API_CLIENT);
 const RefreshChatListeners = CreateChatDataDecorator(ChatDataType.REFRESH_CHAT_LISTENERS);
 
@@ -37,7 +47,7 @@ export {
     MessageUser,
     BroadcasterData, Broadcaster,
     MessageData, Mess,
-    OptionsProvider, ChannelOptions,
+    OptionsProvider, ChannelOptions, OptionsManager,
     API,
     RefreshChatListeners
 };

--- a/src/decorators/Deprecated.decorator.ts
+++ b/src/decorators/Deprecated.decorator.ts
@@ -1,0 +1,15 @@
+import { LoggerFactory } from "../utils/Logger";
+
+export default function deprecated(message: string) {
+    const depLogger = LoggerFactory.createLogger('DeprecatedDecorator');
+    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+        const originalMethod = descriptor.value;
+
+        descriptor.value = function (...args: any[]) {
+            depLogger.warn(`Warning: ${propertyKey} is deprecated. ${message}`);
+            return originalMethod.apply(this, args);
+        };
+
+        return descriptor;
+    };
+}

--- a/src/example/commands/Example.command.ts
+++ b/src/example/commands/Example.command.ts
@@ -1,5 +1,5 @@
 import { ChatCommand } from "../../decorators/ChatCommand.decorator";
-import { API, BroadcasterData, ChannelOptions, Mess, MessageUser, OptionsProvider, Raw, RefreshChatListeners } from "../../decorators/ChatData.decorators";
+import { API, BroadcasterData, ChannelOptions, Mess, MessageUser, OptionsManager, OptionsProvider, Raw, RefreshChatListeners } from "../../decorators/ChatData.decorators";
 import { ChatterUser, PartialTwitchUser } from "../../objects/TwitchUser.object";
 import { ChannelOptionsProvider } from "../../providers/ChannelOptions.provider";
 import { ChatCommandExecution, ChatCommandExecutionGuard, ChatCommandExecutionGuardAvaliableResults, ChatCommandPostExecution, ChatCommandPreExecution } from "../../types/ChatCommand.types";
@@ -23,24 +23,21 @@ export default class ExampleCommand implements ChatCommandExecutionGuard, ChatCo
         return { canAccess: false, message: "You must be a broadcaster, moderator or VIP to use this command." };
     }
 
-    async preExecution(): Promise<void> {
-        console.log('Pre-execution logic');
-    }
+    async preExecution(): Promise<void> {}
 
     async execution(
-        @OptionsProvider() provider: ChannelOptionsProvider<ChannelOptionsExtend>,
-        @ChannelOptions() options: ChannelOptionsExtend,
+        @OptionsManager() optionsManager: ChannelOptionsProvider<ChannelOptionsExtend>,
         @BroadcasterData() broadcasterData: PartialTwitchUser,
         @Mess() message: TwitchChatMessage,
         @RefreshChatListeners() refreshChannels: () => void
     ): Promise<void> {
-        console.log('Execution logic');
+        const options = await optionsManager.getChannelOptions(broadcasterData.getId());
         await message.reply(`Example command executed ${options.eXampleExecutionCounter} times.`);
         if(!options.eXampleExecutionCounter) options.eXampleExecutionCounter = 0;
-        provider.setChannelOptions(broadcasterData.getId(), {
-            ...options,
-            eXampleExecutionCounter: options.eXampleExecutionCounter + 1
-        })
+
+        const saver = optionsManager.getChannelOptionsSaver(broadcasterData.getId());
+        await saver('eXampleExecutionCounter', options.eXampleExecutionCounter + 1);
+
         refreshChannels();
     }
 
@@ -48,7 +45,6 @@ export default class ExampleCommand implements ChatCommandExecutionGuard, ChatCo
             @API() api: APIClient,
             @BroadcasterData() broadcasterData: PartialTwitchUser
         ): Promise<void> {
-            console.log('Post-execution logic');
             const botUserId = api.config.getConfig().userId;
             await api.sendMessage(botUserId, `eXample command executed @ #${broadcasterData.getLogin()}`);
         }

--- a/src/example/commands/Prefix.command.ts
+++ b/src/example/commands/Prefix.command.ts
@@ -1,0 +1,38 @@
+import { ChatCommand } from "../../decorators/ChatCommand.decorator";
+import { Mess, MessageUser, OptionsManager, OptionsProvider } from "../../decorators/ChatData.decorators";
+import CommandsModule from "../../modules/Commands.module";
+import { TwitchChatMessage } from "../../objects/ChatMessage.object";
+import { ChatterUser } from "../../objects/TwitchUser.object";
+import { ChannelOptionsProvider } from "../../providers/ChannelOptions.provider";
+import { ChatCommandExecution, ChatCommandExecutionGuard, ChatCommandExecutionGuardAvaliableResults } from "../../types/ChatCommand.types";
+
+@ChatCommand(CommandsModule.forFeature({
+    name: 'ChangePrefixCommand',
+    keyword: 'prefix'
+}))
+export default class PrefixCommand implements ChatCommandExecution, ChatCommandExecutionGuard {
+    guard(
+        @MessageUser() chatter: ChatterUser,
+    ): ChatCommandExecutionGuardAvaliableResults {
+        if (chatter.isBroadcaster() || chatter.isModerator()) return { canAccess: true };
+        return { canAccess: false, message: 'You do not have permission to execute this command'};
+    }
+
+    async execution(
+        @OptionsManager() options: ChannelOptionsProvider,
+        @Mess() message: TwitchChatMessage
+    ) {
+        console.log('ChangePrefixCommand executed');
+        const messageContent = message.getText();
+        const newPrefix = messageContent.split(' ')[1];
+        if (!newPrefix) {
+            message.reply('You need to specify a prefix');
+            return;
+        }
+
+        const saver = options.getChannelOptionsSaver(message.getBroadcasterId())
+        await saver('prefix', newPrefix);
+
+        message.reply(`Prefix changed to ${newPrefix}`);
+    }
+}

--- a/src/services/ChatDataInjector.service.ts
+++ b/src/services/ChatDataInjector.service.ts
@@ -38,11 +38,15 @@ export default class ChatDataInjectorService {
             [ChatDataType.BROADCASTER]: (data: ChannelChatMessageEventData) => new TwitchUser(data.broadcaster_user_id),
             [ChatDataType.MESSAGE_DATA]: (data: ChannelChatMessageEventData) => new ChatMessage(data),
             [ChatDataType.MESSAGE]: (data: ChannelChatMessageEventData) => new TwitchChatMessage(data),
+            // TODO: Remove
             [ChatDataType.OPTIONS_PROVIDER]: (data: ChannelChatMessageEventData) => DIContainer.get(DINames.ChannelOptionsProvider),
+            // TODO: Remove
             [ChatDataType.CHANNEL_OPTIONS]: async (data: ChannelChatMessageEventData) => {
                 const provider = DIContainer.get(DINames.ChannelOptionsProvider) as ChannelOptionsProvider;
                 return await provider.getChannelOptions(data.broadcaster_user_id);
             },
+            // TODO: This is the same as CHANNEL_OPTIONS - Better name
+            [ChatDataType.OPTIONS_MANAGER]: (data: ChannelChatMessageEventData) => DIContainer.get(DINames.ChannelOptionsProvider),
             [ChatDataType.API_CLIENT]: (data: ChannelChatMessageEventData) => DIContainer.get(DINames.APIClient),
             [ChatDataType.REFRESH_CHAT_LISTENERS]: (data: ChannelChatMessageEventData) => GetListenerChannelsRefreshFunction()
         };

--- a/src/types/ChatDataInjector.types.ts
+++ b/src/types/ChatDataInjector.types.ts
@@ -19,8 +19,10 @@ export enum ChatDataType {
     MESSAGE_DATA = 'MESSAGE_DATA', // Message object (data type: ChatMessage)
     MESSAGE = 'MESSAGE', // Message content (data type: TwitchChatMessage)
 
-    OPTIONS_PROVIDER = 'OPTIONS_PROVIDER', // Channel options provider
-    CHANNEL_OPTIONS = 'CHANNEL_OPTIONS', // Channel options
+    OPTIONS_PROVIDER = 'OPTIONS_PROVIDER', // Channel options provider //TODO: Remove
+    CHANNEL_OPTIONS = 'CHANNEL_OPTIONS', // Channel options //TODO: Remove
+
+    OPTIONS_MANAGER = 'OPTIONS_MANAGER', // Channel options manager
 
     API_CLIENT = 'API_CLIENT', // Twitch API client
 
@@ -40,8 +42,10 @@ export type ChatDataTypeMap = {
     [ChatDataType.MESSAGE_DATA]: ChatMessage;
     [ChatDataType.MESSAGE]: TwitchChatMessage;
 
-    [ChatDataType.OPTIONS_PROVIDER]: ChannelOptionsProvider;
-    [ChatDataType.CHANNEL_OPTIONS]: Record<string, any>; // ChannelBaseOptions & ExtendedByUser
+    [ChatDataType.OPTIONS_PROVIDER]: ChannelOptionsProvider; // TODO: Remove
+    [ChatDataType.CHANNEL_OPTIONS]: Record<string, any>; // ChannelBaseOptions & ExtendedByUser // TODO: Remove
+
+    [ChatDataType.OPTIONS_MANAGER]: ChannelOptionsProvider;
 
     [ChatDataType.API_CLIENT]: APIClient;
 


### PR DESCRIPTION
Deprecated decorators:
- `@OptionsProvider`
- `@ChannelOptions`

Deprecated method:
- `ChannelOptionsProvider</*...*/>.setChannelOptions(/*...*/)`

Add decorator:
- `@OptionsManager` 

Example commands:
- Add command `PrefixCommand`
- The new decorator has been aligned with the command `ExampleCommand`