### PR TITLE
fix/feat/refactor: Improve commands and listeners handling and config checking

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,0 +1,10 @@
+export default class Utils {
+    /**
+     * Get duplicated values from an array
+     * @param values Values array
+     * @returns Duplicated values
+     */
+    static GetDuplicatedValues(values: string[]): string[] {
+        return values.filter((item, index) => values.indexOf(item) != index);
+    }
+}


### PR DESCRIPTION
- add `Utils` class
- refactor `ChatCommandsService` methods
- add `checkCommandsOptionsConfig` in `ChatCommandsService`
  - `name` have to be unique
  - `keyword` and `aliases` should be unique (command-scope)
  - `keyword` and `aliases` have to be unique (global-scope)
- add `checkListenersOptionsConfig` in `ChatListenersService`
  - `name` have to be unique
- better error handling
  - add `name`/`keyword`/`aliases` values in error message
  - check methods are now executed during initialization instead of the first execution of the command