### PR TITLE
ci(workflows): change name of manual-npm-publish-dev

### DIFF
--- a/.github/workflows/manual-npm-publish-dev.yml
+++ b/.github/workflows/manual-npm-publish-dev.yml
@@ -1,4 +1,4 @@
-name: Publish Development to npm
+name: Manual Publish Development to npm
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
- Renamed manual publication run, leftover from copying automatic workflow